### PR TITLE
Subtle bug when defining Policy

### DIFF
--- a/lib/attestor/policy.rb
+++ b/lib/attestor/policy.rb
@@ -32,7 +32,7 @@ module Attestor
     def self.new(*attributes, &block)
       Struct.new(*attributes) do
         include Policy
-        instance_eval(&block) if block_given?
+        class_eval(&block) if block_given?
       end
     end
 

--- a/spec/tests/policy_spec.rb
+++ b/spec/tests/policy_spec.rb
@@ -37,8 +37,14 @@ describe Attestor::Policy do
     end
 
     it "yields the block in class scope" do
-      subject = described_class.new(:foo) { attr_reader :bar }
+      subject = described_class.new(:foo) do
+        attr_reader :bar
+        def foobar; end
+        def self.barfoo; end
+      end
       expect(subject.new(:baz)).to respond_to :bar
+      expect(subject.new(:baz)).to respond_to :foobar
+      expect(subject.new(:baz).class).to respond_to :barfoo
     end
 
   end # describe .new


### PR DESCRIPTION
The following will not work properly

``` rb
ConsistencyPolicy = Attestor::Policy.new(:debet, :credit) do
  def validate!
    fraud = credit - debet
    invalid :inconsistent, fraud: fraud if fraud != 0
  end
end
```

In fact, with the current implementation, `validate!` is defined on the class, thus not available. 

The fix is simply to use class_eval on the struct.
